### PR TITLE
fix type declarations

### DIFF
--- a/mk-string-metrics.lisp
+++ b/mk-string-metrics.lisp
@@ -45,7 +45,7 @@
 (defun hamming (x y)
   "Calculate Hamming distance between two given strings X and Y, they have
 to be of the same length."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (let ((result 0))
@@ -58,14 +58,14 @@ to be of the same length."
 
 (defun levenshtein (x y)
   "Calculate Levenshtein distance between two given strings X and Y."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (let* ((x-len (length x))
          (y-len (length y))
          (v0 (make-array (1+ y-len) :element-type 'array-index))
          (v1 (make-array (1+ y-len) :element-type 'array-index)))
-    (declare (type (simple-array array-index) v0 v1))
+    (declare (type (simple-array array-index (*)) v0 v1))
     (dotimes (i (1+ y-len))
       (declare (type array-index i))
       (setf (aref v0 i) i))
@@ -86,7 +86,7 @@ to be of the same length."
 (defun damerau-levenshtein (x y)
   "Calculate Damerau-Levenshtein distance between two given strings X and
 Y."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (let* ((x-len (length x))
@@ -94,7 +94,7 @@ Y."
          (v0 (make-array (1+ y-len) :element-type 'array-index))
          (v1 (make-array (1+ y-len) :element-type 'array-index))
          (v* (make-array (1+ y-len) :element-type 'array-index)))
-    (declare (type (simple-array array-index) v0 v1 v*))
+    (declare (type (simple-array array-index (*)) v0 v1 v*))
     (dotimes (i (1+ y-len))
       (declare (type array-index i))
       (setf (aref v0 i) i))
@@ -147,7 +147,7 @@ strings, while 1 means exact match."
 
 (defun string-to-set (str)
   "Convert string STR into a set. This function is supposed to be inlined."
-  (declare (type (simple-array character) str)
+  (declare (type simple-string str)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (let ((result (make-hash-table)))
@@ -203,7 +203,7 @@ to be inlined."
   "This function calculates overlap coefficient between two given strings X
 and Y. Returned value is in range from 0 (no similarity) to 1 (exact
 match)."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (/ (the array-index (intersection-length (string-to-set x)
@@ -214,7 +214,7 @@ match)."
 (defun jaccard (x y)
   "Calculate Jaccard similarity coefficient for two strings X and
 Y. Returned value is in range from 0 (no similarity) to 1 (exact match)."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (optimize (safety 0) (speed 3) (space 3)))
   (let ((x (string-to-set x))
         (y (string-to-set y)))
@@ -227,7 +227,7 @@ Y. Returned value is in range from 0 (no similarity) to 1 (exact match)."
 (defun fast-find (char str str-len &optional (start 0))
   "Check if CHAR is in STR. This function is supposed to be inlined."
   (declare (type character char)
-           (type (simple-array character) str)
+           (type simple-string str)
            (type array-index str-len start)
            (optimize (safety 0) (speed 3) (space 3)))
   (do ((i start (1+ i)))
@@ -239,7 +239,7 @@ Y. Returned value is in range from 0 (no similarity) to 1 (exact match)."
 (defun jaro (x y)
   "Calculate Jaro distance between two strings X and Y. Returned value is in
 range from 0 (no similarity) to 1 (exact match)."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 1) (space 3)))
   (let* ((x-len (length x))
@@ -277,7 +277,7 @@ range from 0 (no similarity) to 1 (exact match)."
 
 (defun prefix-length (x y)
   "Calculate length of common prefix for strings X and Y."
-  (declare (type (simple-array character) x y)
+  (declare (type simple-string x y)
            (inline length)
            (optimize (safety 0) (speed 3) (space 3)))
   (let ((x-len (length x))


### PR DESCRIPTION
The inputs being declared `(simple-array character)` was causing me to run into some incorrect behavior on SBCL 2.0.11, but changing them to `simple-string`s fixed it. I also updated a couple of other type declarations that could've been more specific while I was at it.